### PR TITLE
No

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,7 @@ import subprocess
 
 def main():
     """ main function """
-    try:
-        print ("Installing dependencies...")
-        subprocess.call(['sudo', 'pip', 'install', '-r', 'requirements.txt'])
-        print ("Installing AWS CLI") # WINDOWS HAS NO SUDO
-        subprocess.call(['sudo', 'pip', 'install', 'awscli', '--ignore-installed', 'six'])
-        print ("Installing sshpass")
-        subprocess.call(['sudo', 'tar', '-xvf', 'sshpass-1.06.tar.gz'], cwd = './tools')
-        subprocess.check_output(['sudo', './configure'], cwd='tools/sshpass-1.06')
-        subprocess.call(['sudo', 'make', 'install'], cwd='tools/sshpass-1.06/')
-        print ("Please enter your AWS credetionals")
-        subprocess.call(['aws', 'configure'])
-    except:
-        print ("FAILED in one of the steps")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Why on earth would this package try to sudo via a suprocess.call shell command in setup.py? The correct way to depend on sshpass is to note it as a dependency and let users install it themselves.