### PR TITLE
Ignore deleted CloudFormation stacks

### DIFF
--- a/scripts/audit_aws_cloud_formation.sh
+++ b/scripts/audit_aws_cloud_formation.sh
@@ -15,7 +15,7 @@
   #printf "##############${NC}\n\n"
   account=`aws sts get-caller-identity --output text --query 'Account'`
 for  aws_region in ap-south-1 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1 sa-east-1 ca-central-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1 us-east-2 us-west-1 us-west-2;do
-  stacks=`aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackId' --output text` 
+  stacks=`aws cloudformation list-stacks --region $aws_region --query "StackSummaries[?StackStatus != 'DELETE_COMPLETE'].StackId" --output text` 
   for stack in $stacks; do 
     check=`aws cloudformation describe-stacks --region $aws_region --stack-name $stack --query 'Stack[].NotificationARNs' --output text`
     stack=`printf "$stack" |cut -f2 -d/`
@@ -26,7 +26,7 @@ for  aws_region in ap-south-1 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1 
     fi
   done
   # Check stacks have a policy
-  stacks=`aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackName' --output text`
+  stacks=`aws cloudformation list-stacks --region $aws_region --query "StackSummaries[?StackStatus != 'DELETE_COMPLETE'].StackName" --output text`
     for stack in $stacks; do 
     check=`aws cloudformation get-stack-policy --region $aws_region --stack-name $stack --query 'StackPolicyBody' --output text 2> /dev/null`
     if [ ! "$check" ]; then


### PR DESCRIPTION
Implements a query filter on `StackStatus` to ignore CloudFormation stacks that have `DELETE_COMPLETE` as `StackStatus`. This will reduce the executing time significantly on some AWS accounts.

**Reason:** Performing an audit on an AWS account with a big amount of deleted CloudFormation stacks takes very long. The checks that are modified by this change do not make sense on deleted stacks. These checks are:
- Check Cloud Formation stacks are using SNS
- Check stacks have a policy